### PR TITLE
fixed transaction ID extraction from response

### DIFF
--- a/ruby/demos/trivial/adams.rb
+++ b/ruby/demos/trivial/adams.rb
@@ -56,7 +56,7 @@ resp = client.execute(
   :body_object => {})
 
 # Get the transaction handle
-tx = Base64.encode64(resp.data.transaction)
+tx = JSON.parse(resp.response.body)['transaction']
 
 # Get the entity by key.
 resp = client.execute(


### PR DESCRIPTION
The transaction ID is not a Base64-encoded value (probably it was in previous version of API?), so decode/encode does not work.
Simply extract the original string from JSON response and use it later.
